### PR TITLE
Bluez workaround

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.pyc
+build/lib/*
+docs/_build/*
+*.egg-info
+.coverage
+.DS_Store

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,29 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+`2.2.1`_ (2026-04-08)
+=====================
+
+Added
+-----
+
+* Added references to pairing mode section of docs in README.md and examples.
+* Added disclaimer to docs.
+* Added a link to the main page of the docs to the docs index/navbar.
+* Added a note to the docs about using Bluetooth and Zigbee at the same time.
+
+Changed
+-------
+
+* Updated the supported operating systems section of the docs with tested MacOS version and ESPHome support.
+* Improved the pairing docs to better describe setup and include links to Hue docs.
+
+Fixed
+-----
+
+* Fixed an error when receiving certain types of state updates from the effects API.
+* Fixed ``org.bluez.Error.AuthenticationFailed`` error when pairing using BlueZ 5.78+.
+
 `2.2.0`_ (2026-03-23)
 =====================
 
@@ -191,6 +214,7 @@ Fixed
 
 * HueBLE created.
 
+.. _2.2.1: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.1
 .. _2.2.0: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.0
 .. _2.1.1: https://github.com/flip-dots/HueBLE/releases/tag/v2.1.1
 .. _2.1.0: https://github.com/flip-dots/HueBLE/releases/tag/v2.1.0

--- a/HueBLE.py
+++ b/HueBLE.py
@@ -461,7 +461,7 @@ class HueBleLight(object):
                     )
                 elif len(data) == 10:
                     # bulb is in temperature mode, we got onoff, brightness and temperature
-                    brightness, colour_temp = unpack(
+                    onoff, brightness, colour_temp = unpack(
                         UNPACK_EFFECT_API_TEMPERATURE_WITHOUT_EFFECT, data
                     )
                     self._colour_temp = colour_temp

--- a/HueBLE.py
+++ b/HueBLE.py
@@ -7,13 +7,19 @@
 import asyncio
 import logging
 import platform
+import uuid
 from bleak import BleakClient, BleakError, BleakScanner
+from bleak.backends import BleakBackend
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.device import BLEDevice
 from bleak_retry_connector import establish_connection
 from struct import pack, unpack
 from typing import Callable
 from enum import Enum
+from dbus_fast.aio import MessageBus
+from dbus_fast.service import ServiceInterface, method
+from dbus_fast import BusType
+
 
 #: String containing manufacturer. Handle 15.
 UUID_MANUFACTURER = "00002a29-0000-1000-8000-00805f9b34fb"
@@ -79,9 +85,6 @@ DEFAULT_ON_CONNECT_RUN_CALLBACKS = True
 
 #: Default time to wait for a pairing request to complete.
 DEFAULT_PAIR_TIMEOUT = 15
-
-#: Default time to wait after pairing to check if it was successful.
-DEFAULT_PAIR_DELAY = 5
 
 #: Default max time before a call to poll state times out.
 DEFAULT_POLL_STATE_TIMEOUT = 45
@@ -662,13 +665,12 @@ class HueBleLight(object):
         try:
             _LOGGER.debug(f"""Attempting to pair to "{self.name}".""")
             async with asyncio.timeout(DEFAULT_PAIR_TIMEOUT):
-                await self._client.pair()
 
-            await asyncio.sleep(DEFAULT_PAIR_DELAY)
-            if self.authenticated is False:
-                raise Exception(
-                    f"""Failed to pair to "{self.name}". System reports not paired after pair attempt!"""
-                )
+                if self._client.backend_id is BleakBackend.BLUEZ_DBUS:
+                    _LOGGER.debug("Using bluez workaround...")
+                    await self._pair_bluez()
+                else:
+                    await self._client.pair()
 
         except asyncio.TimeoutError as e:
             raise PairingError(
@@ -679,6 +681,51 @@ class HueBleLight(object):
             raise PairingError(
                 f"""Error from Bluetooth backend when attempting to pair to "{self.name}". E: "{e}"."""
             ) from e
+
+    async def _pair_bluez(self):
+        """Workaround for bluez authentication issues."""
+
+        class BluezAgent(ServiceInterface):
+            """Agent for automatically accepting pairing passkeys."""
+
+            def __init__(self):
+                super().__init__("org.bluez.Agent1")
+
+            @method()
+            def RequestConfirmation(self, device: "o", passkey: "u"):
+                _LOGGER.debug(f"Auto confirming passkey {passkey} for {device}")
+                return
+
+            @method()
+            def Cancel(self):
+                _LOGGER.debug("Pairing cancelled by device")
+
+        # Build agent
+        _LOGGER.debug("Setting up pairing agent...")
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+        agent = BluezAgent()
+        unique_id = uuid.uuid4().hex[:8]
+        agent_path = f"/com/bleak/agent/hue_ble/{unique_id}"
+        bus.export(agent_path, agent)
+
+        # Register agent
+        introspection = await bus.introspect("org.bluez", "/org/bluez")
+        proxy_object = bus.get_proxy_object("org.bluez", "/org/bluez", introspection)
+        agent_manager = proxy_object.get_interface("org.bluez.AgentManager1")
+        await agent_manager.call_register_agent(agent_path, "KeyboardDisplay")
+        _LOGGER.debug("Pairing agent ready!")
+
+        async with asyncio.timeout(DEFAULT_PAIR_TIMEOUT):
+
+            try:
+                await asyncio.sleep(1)
+                _LOGGER.debug("Sending pairing command...")
+                await self._client.pair()
+            finally:
+                _LOGGER.debug("Stopping pairing agent...")
+                await agent_manager.call_unregister_agent(agent_path)
+                bus.unexport(agent_path, agent)
+                bus.disconnect()
 
     async def _determine_services(self) -> None:
         """Determines what features the light supports.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ same directory as your program. If you are using manual installation make sure
 the dependencies are installed as well.
 
 ```
-pip install bleak bleak-retry-connector
+pip install bleak bleak-retry-connector dbus-fast
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -131,3 +131,8 @@ if __name__ == "__main__":
 ### Demo program
 
 A more fully featured demo program can be found in  ``` examples/demo.py ``` which demonstrates all of the implemented features.
+
+
+## Disclaimer
+
+HueBLE is a software library designed to work with Philips Hue. Philips Hue is a registered trademark of Philips. This project is not affiliated with, endorsed by, or sponsored by Philips (Though I wouldn't mind being sponsored 😉). All other trademarks cited herein are the property of their respective owners.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,16 @@ It leverages the Bleak library to interact with Bluetooth Philips Hue lights.
 ## Supported Operating Systems
 
 - 🐧 Linux (BlueZ)
-  - Ubuntu Desktop
-  - Arch (HomeAssistant OS)
+  - Ubuntu Desktop (24.04)
+  - Arch 
+  - Buildroot (HomeAssistant OS)
 - 🏢 Windows
   - Windows 10 
 - 💾 Mac OSX
-  - Maybe?
+  - Sequoia (15.7)
+- 🛜 ESPHome (Bluetooth Proxy)
+  - ESP32-C3-Super-Mini
+  - ESP32-C5-N4R2
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ pip install bleak bleak-retry-connector
 
 Example code from example.py
 
+> [!NOTE]
+> Do not forget to put the light in [pairing mode](https://hueble.readthedocs.io/en/latest/usage.html#pairing) before first connection!
+
 ```python
 import asyncio
 from bleak import BleakScanner

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==7.2.5
 sphinx-rtd-theme==2.0.0
-HueBLE==2.2.0
+HueBLE==2.2.1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, project_root)
 project = "HueBLE"
 copyright = "2025, Harvey Lelliott"
 author = "Harvey Lelliott"
-release = "2.2.0"
+release = "2.2.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -10,6 +10,9 @@ Basic Example
 Simple blinky light example demonstrating making a connection to a light
 from its MAC address and making it turn off then on again.
 
+.. note::
+   Do not forget to put the light in :ref:`pairing mode <pairing_label>` before first connection!
+
 .. literalinclude:: ../../examples/example.py
     :language: python
     :linenos:
@@ -33,6 +36,9 @@ the module using a push based approach.
     - 🌈 XY Colour
     - 🌟 Effects
 - ✔️ Notifications of state changes to the light via push approach
+
+.. note::
+   Do not forget to put the light in :ref:`pairing mode <pairing_label>` before first connection!
 
 .. literalinclude:: ../../examples/demo.py
     :language: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,8 +57,9 @@ Supported Operating Systems
 
 - 🐧 Linux (BlueZ)
 
-  - ✔️ Ubuntu Desktop
-  - ✔️ Arch (HomeAssistant OS)
+  - ✔️ Ubuntu Desktop (24.04)
+  - ✔️ Arch 
+  - ✔️ Buildroot (HomeAssistant OS)
 
 - 🏢 Windows
 
@@ -66,7 +67,13 @@ Supported Operating Systems
 
 - 💾 Mac OSX
 
-  - ❓ Maybe?
+  - ✔️ Sequoia (15.7)
+  
+- 🛜 ESPHome (Bluetooth Proxy)
+
+  - ESP32-C3-Super-Mini
+  - ESP32-C5-N4R2
+
 
 Contents
 --------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,6 +91,7 @@ Contents
 .. toctree::
    :maxdepth: 2
 
+   self
    installation
    usage
    examples

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,6 +75,16 @@ Supported Operating Systems
   - ESP32-C5-N4R2
 
 
+Disclaimer
+----------
+
+HueBLE is a software library designed to work with Philips Hue. 
+Philips Hue is a registered trademark of Philips. 
+This project is not affiliated with, endorsed by, or sponsored by Philips 
+(Though I wouldn't mind being sponsored 😉). 
+All other trademarks cited herein are the property of their respective owners.
+
+
 Contents
 --------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -18,4 +18,4 @@ HueBLE consists of a single file (``HueBLE.py``) which you can simply put in the
 same directory as your program. If you are using manual installation make sure
 the dependencies are installed as well.
 
-``pip install bleak bleak-retry-connector``
+``pip install bleak bleak-retry-connector dbus-fast``

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -96,6 +96,8 @@ by subsequently calling the :py:meth:`.poll_state` method.
 ``await light.poll_state()``
 
 
+.. _pairing_label:
+
 Pairing
 ^^^^^^^
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -102,16 +102,27 @@ Pairing
 ^^^^^^^
 
 On connection to a light this module will attempt to pair to the light
-if it is not already paired. To pair with a light it must be in pairing mode,
-this can be activated in the Philips Hue app. Resetting the light also puts it in pairing mode.
+if it is not already paired. To pair with a light it **must** be in pairing mode,
+unconfigured lights are in pairing mode by default but this can also be achieved by
+using the `voice assistant pairing feature <https://www.philips-hue.com/en-us/explore-hue/works-with/amazon-alexa/set-up>`_
+in the Phillips Hue App (`Android <https://play.google.com/store/apps/details?id=com.philips.lighting.hue2>`_
+/`iOS <https://apps.apple.com/us/app/philips-hue/id1055281310>`_) or by 
+`factory resetting <https://www.philips-hue.com/en-us/support/article/how-to-factory-reset-philips-hue-lights/000004>`_ 
+the light.
 
 ``Settings -> Voice Assistants -> 
 Amazon Alexa or Google Home -> Make Discoverable``
 
 .. note::
 
-    If you are not using Linux automatic pairing may not be possible and you
-    will have to pair the lights in your OS.
+    If you `factory reset <https://www.philips-hue.com/en-us/support/article/how-to-factory-reset-philips-hue-lights/000004>`_ the light
+    its Bluetooth address will change as it is randomly generated.
+
+.. note::
+
+    Pairing automatically is `not supported <https://bleak.readthedocs.io/en/latest/backends/macos.html#pairing>`_ on MacOS, you
+    will be prompted to pair to the light by the OS upon first connection. Further connections will not
+    require this unless the light is reset.
 
 
 Full state updates
@@ -258,3 +269,17 @@ Other neat things
 
 - You can set attributes such as colour while the light is in the off state 
   without turning the light on.
+
+- Hue lights connected using Zigbee are still discoverable and controllable by 
+  this module, even if they are connected to another Zigbee network or bound
+  to a Zigbee switch. This means you can use Zigbee and Bluetooth at the same time.
+  This can be done by pairing the light to the Zigbee hub or switch and then using
+  the Hue app in Bluetooth mode to connect to the light over Bluetooth using the
+  QR code on the side of the light and then using the Alexa/Google pairing steps.
+
+  .. note::
+
+    The Hue app will not let you setup a light using Bluetooth if it is already
+    connected to a Hue hub that the app is aware of, the workaround is to remove
+    the Hub from the Hue app or use a fresh install/device that is not paired with the hub.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HueBLE"
-version = "2.2.0"
+version = "2.2.1"
 dependencies = [
   "bleak>=0.19.0",
   "bleak-retry-connector",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ name = "HueBLE"
 version = "2.2.0"
 dependencies = [
   "bleak>=0.19.0",
-  "bleak-retry-connector"
+  "bleak-retry-connector",
+  "dbus-fast"
 ]
 requires-python = ">= 3.11"
 authors = [

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ pytest-asyncio
 pytest-cov
 bleak
 bleak-retry-connector
+dbus-fast

--- a/tests/test_HueBLE.py
+++ b/tests/test_HueBLE.py
@@ -94,7 +94,9 @@ from tests.helpers import MockDevice, sleep_side_effect
             HueBLE.UUID_EFFECTS,
             bytes.fromhex("01010102015004049bc54f3606010108015e"),
             {
-                HueBLE.UUID_EFFECTS: bytes.fromhex("01010102015004049bc54f3606010108015e"),
+                HueBLE.UUID_EFFECTS: bytes.fromhex(
+                    "01010102015004049bc54f3606010108015e"
+                ),
             },
             "set_colour_effect",
             [0.77191, 0.21215, 80, HueBLE.EffectType.CANDLE, 94],
@@ -102,7 +104,6 @@ from tests.helpers import MockDevice, sleep_side_effect
                 "effect": (HueBLE.EffectType.CANDLE, 94),
                 "colour_xy": (0.7719081406881819, 0.21214618142977035),
                 "colour_temp_mode": False,
-
             },
             id="colour_effect",
         ),
@@ -118,7 +119,6 @@ from tests.helpers import MockDevice, sleep_side_effect
                 "effect": (HueBLE.EffectType.CANDLE, 94),
                 "colour_temp": 300,
                 "colour_temp_mode": True,
-
             },
             id="temperature_effect",
         ),
@@ -329,7 +329,9 @@ async def test_commands(
                 HueBLE.UUID_FW_VERSION: "c.a.f.f.e.e".encode(),
                 HueBLE.UUID_ZIGBEE_ADDRESS: bytes.fromhex("00010203040506070809"),
                 HueBLE.UUID_NAME: "Tea light".encode(),
-                HueBLE.UUID_EFFECTS: bytes.fromhex("01010102015004046666ff7f06010108015e"),
+                HueBLE.UUID_EFFECTS: bytes.fromhex(
+                    "01010102015004046666ff7f06010108015e"
+                ),
             },
             {
                 "manufacturer": "atmospheric lights",
@@ -686,21 +688,6 @@ async def test_authenticated(
                 "Timed out attempting to pair",
             ],
             id="pair_timeout",
-        ),
-        pytest.param(
-            None,
-            True,
-            None,
-            False,
-            None,
-            None,
-            None,
-            HueBLE.ConnectionError,
-            [
-                "Exception connecting to light",
-                "System reports not paired after",
-            ],
-            id="pair_failed",
         ),
         pytest.param(
             None,


### PR DESCRIPTION
There have been a lot of issues reported with "org.bluez.Error.AuthenticationFailed" when attempting to pair using Linux and this seems to be caused by newer versions of BlueZ (older versions work fine). 

Issues:
- https://github.com/home-assistant/core/issues/158030
- https://github.com/home-assistant/core/issues/158157
- https://github.com/home-assistant/home-assistant.io/issues/42158

I ended up looking into it further (for like the 5th time at this point) and looking at the logs output by btmon and it seemed to indicate that there was something wrong with the pairing agent (something to tell it what to do if the device wants a pin, passkey, or confirmation). So this PR adds a simple pairing agent that just always says yes to pairing requests. Its not great and bleak is supposed to be adding support for it [natively](https://github.com/hbldh/bleak/pull/1864) at some point so this hacky workaround won't be needed.

I am not sure why the original code stopped working with newer versions of BlueZ, a quick peek at the issues on BlueZ shows that others are having similar issues but nothing in the release notes for BlueZ indicates a changing to pairing agents, so ¯\\_(ツ)_/¯. 

Issues:
- https://github.com/bluez/bluez/issues/1395
- https://github.com/bluez/bluez/issues/911
- https://github.com/bluez/bluez/issues/688

This PR fixes the issue on my Laptop with an Intel Bluetooth card using BlueZ 5.85 but it would be great if others could confirm if this fix works for them.


 
