### PR TITLE
Fix dbus-fast import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+`2.2.2`_ (2026-04-16)
+=====================
+
+Fixed
+-----
+
+* Fixed dbus-fast dependency being imported on non-Linux platforms.
+* Fixed dbus-fast dependency being installed on non-Linux platforms.
+
 `2.2.1`_ (2026-04-08)
 =====================
 
@@ -214,6 +223,7 @@ Fixed
 
 * HueBLE created.
 
+.. _2.2.2: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.2
 .. _2.2.1: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.1
 .. _2.2.0: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.0
 .. _2.1.1: https://github.com/flip-dots/HueBLE/releases/tag/v2.1.1

--- a/HueBLE.py
+++ b/HueBLE.py
@@ -16,9 +16,6 @@ from bleak_retry_connector import establish_connection
 from struct import pack, unpack
 from typing import Callable
 from enum import Enum
-from dbus_fast.aio import MessageBus
-from dbus_fast.service import ServiceInterface, method
-from dbus_fast import BusType
 
 
 #: String containing manufacturer. Handle 15.
@@ -684,6 +681,9 @@ class HueBleLight(object):
 
     async def _pair_bluez(self):
         """Workaround for bluez authentication issues."""
+        from dbus_fast.aio import MessageBus
+        from dbus_fast.service import ServiceInterface, method
+        from dbus_fast import BusType
 
         class BluezAgent(ServiceInterface):
             """Agent for automatically accepting pairing passkeys."""

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==7.2.5
 sphinx-rtd-theme==2.0.0
-HueBLE==2.2.1
+HueBLE==2.2.2

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,7 @@ sys.path.insert(0, project_root)
 project = "HueBLE"
 copyright = "2025, Harvey Lelliott"
 author = "Harvey Lelliott"
-release = "2.2.1"
+release = "2.2.2"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HueBLE"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
   "bleak>=0.19.0",
   "bleak-retry-connector",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.2.1"
 dependencies = [
   "bleak>=0.19.0",
   "bleak-retry-connector",
-  "dbus-fast"
+  "dbus-fast; sys_platform == 'linux'"
 ]
 requires-python = ">= 3.11"
 authors = [


### PR DESCRIPTION
The current pyproject.toml will attempt to install dbus-fast on non-Linux platforms and that will fail. The code also attempts to import dbus-fast on non-Linux platforms which also fails. I probably should have seen that coming, oh well.

This should fix #10.