### PR TITLE
Catch unsupported effects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
+`2.2.3`_ (2026-08-21)
+=====================
+
+Added
+-----
+
+* Added section about unknown effect types to the docs.
+
+Fixed
+-----
+
+* Log warning message instead of raising an exception when an unknown effect type is reported. 
+
 `2.2.2`_ (2026-04-16)
 =====================
 
@@ -223,6 +236,7 @@ Fixed
 
 * HueBLE created.
 
+.. _2.2.3: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.3
 .. _2.2.2: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.2
 .. _2.2.1: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.1
 .. _2.2.0: https://github.com/flip-dots/HueBLE/releases/tag/v2.2.0

--- a/HueBLE.py
+++ b/HueBLE.py
@@ -17,7 +17,6 @@ from struct import pack, unpack
 from typing import Callable
 from enum import Enum
 
-
 #: String containing manufacturer. Handle 15.
 UUID_MANUFACTURER = "00002a29-0000-1000-8000-00805f9b34fb"
 
@@ -147,6 +146,13 @@ class EffectType(Enum):
     COSMOS = 0x0F
     SUNBEAM = 0x10
     ENCHANT = 0x11
+
+    @classmethod
+    def _missing_(cls, value):
+        _LOGGER.warning(
+            f"Unknown effect type: '{value}' reported by light, using default of none!"
+        )
+        return cls.NONE
 
 
 #: EFFECT_COMMANDS (hex string) for the Effect Characteristic endpoint containing one byte id and one byte data length

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx==7.2.5
 sphinx-rtd-theme==2.0.0
-HueBLE==2.2.2
+HueBLE==2.2.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,9 +15,9 @@ project_root = os.path.dirname(cwd)
 sys.path.insert(0, project_root)
 
 project = "HueBLE"
-copyright = "2025, Harvey Lelliott"
+copyright = "2026, Harvey Lelliott"
 author = "Harvey Lelliott"
-release = "2.2.2"
+release = "2.2.3"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -249,6 +249,12 @@ a enum of possible effects and the effect speed as a number between 0 and 255. T
 - :py:meth:`.set_effect`
 - :py:meth:`.set_temperature_effect`
 
+  .. note::
+
+    If an unknown effect is reported by the device a warning message will be printed to the log and the effect type will
+    default to the None effect. If you wish to add support for an unknown effect, raise an issue which identifies the 
+    effect type value and the name of the effect in the Hue app or submit a PR which adds the effect type to the EffectType 
+    enum.
 
 
 Automatic Reconnection 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "HueBLE"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
   "bleak>=0.19.0",
   "bleak-retry-connector",

--- a/tests/test_HueBLE.py
+++ b/tests/test_HueBLE.py
@@ -370,6 +370,29 @@ async def test_commands(
             },
             id="temperature_effect",
         ),
+        pytest.param(
+            {
+                HueBLE.UUID_MANUFACTURER: "Philippe Hue".encode(),
+                HueBLE.UUID_MODEL: "Fancy new light".encode(),
+                HueBLE.UUID_FW_VERSION: "1.7.10".encode(),
+                HueBLE.UUID_ZIGBEE_ADDRESS: bytes.fromhex("00010203040506070809"),
+                HueBLE.UUID_NAME: "L A M P".encode(),
+                HueBLE.UUID_EFFECTS: bytes.fromhex("01010102014503022c01060115080138"),
+            },
+            {
+                "manufacturer": "Philippe Hue",
+                "model": "Fancy new light",
+                "firmware": "1.7.10",
+                "zigbee_address": "00:01:02:03:04:05:06:07:08:09",
+                "name_in_app": "L A M P",
+                "power_state": True,
+                "brightness": 69,
+                "colour_temp": 300,
+                "colour_xy": None,
+                "effect": (HueBLE.EffectType.NONE, 56),
+            },
+            id="unknown_effect",
+        ),
     ],
 )
 async def test_poll_state(


### PR DESCRIPTION
The library currently raises an exception if the light reports an unknown effect type. This PR changes this so that a warning message is logged instead and the effect type defaults to the None effect. This PR also updates the changelog and bumps the version in preparation for a bugfix release.

This was created to address #12 in which the Hue Surimu light uses an unknown effect type when it has not been setup, this should allow for the light to be paired and used successfully.